### PR TITLE
Add PS/2 mouse driver and simple GUI controls

### DIFF
--- a/kernel/GNUmakefile
+++ b/kernel/GNUmakefile
@@ -109,6 +109,7 @@ CFILES := \
     src/serial.c \
     src/shell.c \
     src/gui.c \
+    src/mouse.c \
     src/syscall.c \
     src/usermode_return.c \
     src/vmm.c

--- a/kernel/src/src/gui.h
+++ b/kernel/src/src/gui.h
@@ -17,4 +17,25 @@ void gui_draw_window(struct gui_context *ctx, int x, int y, int w, int h,
                      uint32_t bg_color, uint32_t border_color);
 void gui_draw_desktop(struct gui_context *ctx);
 
+enum gui_window_state {
+    GUI_WINDOW_NORMAL,
+    GUI_WINDOW_MINIMIZED,
+    GUI_WINDOW_MAXIMIZED,
+    GUI_WINDOW_CLOSED
+};
+
+struct gui_window {
+    int x;
+    int y;
+    int w;
+    int h;
+    enum gui_window_state state;
+};
+
+void gui_draw_window_ex(struct gui_context *ctx, struct gui_window *win,
+                        uint32_t bg_color, uint32_t border_color);
+bool gui_window_handle_click(struct gui_window *win, int x, int y);
+void gui_draw_cursor(struct gui_context *ctx, int x, int y, uint32_t color);
+void gui_run_demo(struct gui_context *ctx);
+
 #endif // GUI_H

--- a/kernel/src/src/mouse.c
+++ b/kernel/src/src/mouse.c
@@ -1,0 +1,87 @@
+#include "mouse.h"
+#include <stdint.h>
+
+#define PS2_DATA_PORT    0x60
+#define PS2_STATUS_PORT  0x64
+#define PS2_COMMAND_PORT 0x64
+
+static inline uint8_t inb(uint16_t port) {
+    uint8_t ret;
+    __asm__ volatile ("inb %1, %0" : "=a"(ret) : "Nd"(port));
+    return ret;
+}
+
+static inline void outb(uint16_t port, uint8_t val) {
+    __asm__ volatile ("outb %0, %1" :: "a"(val), "Nd"(port));
+}
+
+static void mouse_wait_input(void) {
+    while (inb(PS2_STATUS_PORT) & 0x02);
+}
+
+static void mouse_wait_output(void) {
+    while (!(inb(PS2_STATUS_PORT) & 0x01));
+}
+
+static void mouse_write(uint8_t val) {
+    mouse_wait_input();
+    outb(PS2_COMMAND_PORT, 0xD4);
+    mouse_wait_input();
+    outb(PS2_DATA_PORT, val);
+}
+
+static uint8_t mouse_read(void) {
+    mouse_wait_output();
+    return inb(PS2_DATA_PORT);
+}
+
+static struct mouse_state ms;
+static int8_t packet[3];
+static int packet_cycle = 0;
+
+void mouse_init(void) {
+    ms.x = ms.y = ms.dx = ms.dy = 0;
+    ms.buttons = 0;
+
+    mouse_wait_input();
+    outb(PS2_COMMAND_PORT, 0xA8); // enable auxiliary device
+    mouse_wait_input();
+    outb(PS2_COMMAND_PORT, 0x20); // get command byte
+    mouse_wait_output();
+    uint8_t status = inb(PS2_DATA_PORT);
+    status |= 2; // enable interrupt from mouse
+    mouse_wait_input();
+    outb(PS2_COMMAND_PORT, 0x60); // set command byte
+    mouse_wait_input();
+    outb(PS2_DATA_PORT, status);
+
+    // default settings
+    mouse_write(0xF6); mouse_read();
+    // enable packet streaming
+    mouse_write(0xF4); mouse_read();
+}
+
+struct mouse_state *mouse_get_state(void) {
+    return &ms;
+}
+
+void mouse_poll(void) {
+    if (!(inb(PS2_STATUS_PORT) & 1))
+        return;
+
+    int8_t data = inb(PS2_DATA_PORT);
+    packet[packet_cycle++] = data;
+    if (packet_cycle < 3)
+        return;
+    packet_cycle = 0;
+
+    ms.buttons = packet[0] & 0x07;
+    int dx = packet[1];
+    int dy = -packet[2];
+    ms.dx = dx;
+    ms.dy = dy;
+    ms.x += dx;
+    ms.y += dy;
+    if (ms.x < 0) ms.x = 0;
+    if (ms.y < 0) ms.y = 0;
+}

--- a/kernel/src/src/mouse.h
+++ b/kernel/src/src/mouse.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <stdint.h>
+
+struct mouse_state {
+    int x;
+    int y;
+    int dx;
+    int dy;
+    uint8_t buttons;
+};
+
+void mouse_init(void);
+void mouse_poll(void);
+struct mouse_state *mouse_get_state(void);

--- a/kernel/src/src/shell.c
+++ b/kernel/src/src/shell.c
@@ -206,8 +206,7 @@ static void shell_exec(const char *cmd, char *argv[], int argc) {
         // Halt if reboot doesn't happen immediately
         for (;;) { asm volatile ("cli; hlt"); }
     } else if (!strcmp(cmd, "gui")) {
-        gui_draw_desktop(&gui_ctx);
-        for (;;) { asm volatile("cli; hlt"); }
+        gui_run_demo(&gui_ctx);
     } else if (!strcmp(cmd, "pwd")) {
         // Print working directory
         const char *cwd = fs_get_current_dir();


### PR DESCRIPTION
## Summary
- implement basic PS/2 mouse polling driver
- extend GUI with window state handling and a cursor
- add a demo loop for GUI interaction
- update shell command to launch the new demo
- include new source in kernel build

## Testing
- `make -C kernel` *(fails: Please run the ./get-deps script first)*