### PR TITLE
Implement chmod command and basic user system

### DIFF
--- a/kernel/src/src/fs.c
+++ b/kernel/src/src/fs.c
@@ -101,6 +101,7 @@ void fs_init(void) {
         memcpy(dst->data, src->data, src->size);
         dst->size = src->size;
         dst->is_dir = false;
+        dst->mode = 0644;
         dst->fs_type = FS_TYPE_INITRAMFS;
     }
     
@@ -341,6 +342,7 @@ struct fs_file *fs_create_file(const char *name) {
     file->size = 0;
     file->data[0] = '\0'; // Empty string
     file->is_dir = false;
+    file->mode = 0644;
     file->fs_type = FS_TYPE_INITRAMFS;
     
     return file;
@@ -439,5 +441,14 @@ bool fs_create_dir(const char *name) {
     // Ensure null termination just in case (should be handled by strcpy/strcat)
     dir->path[max_len - 1] = '\0';
 
+    return true;
+}
+
+bool fs_chmod(const char *name, unsigned short mode) {
+    struct fs_file *f = fs_open(name);
+    if (!f) {
+        return false;
+    }
+    f->mode = mode;
     return true;
 }

--- a/kernel/src/src/fs.h
+++ b/kernel/src/src/fs.h
@@ -22,6 +22,7 @@ struct fs_file {
     char *data;         // File content (mutable)
     size_t size;        // File size
     size_t capacity;    // Allocated capacity for data
+    unsigned short mode; // Permission bits (e.g. 0644)
     bool is_dir;        // Whether this entry is a directory
     fs_type_t fs_type;  // Which filesystem this file belongs to
 };
@@ -71,5 +72,8 @@ size_t fs_write(struct fs_file *file, size_t offset, const void *buf, size_t len
 
 // Create a new directory
 bool fs_create_dir(const char *name);
+
+// Change permissions of a file
+bool fs_chmod(const char *name, unsigned short mode);
 
 #endif // FS_H


### PR DESCRIPTION
## Summary
- add file permission field and fs_chmod helper
- expose fs_chmod in header
- introduce users and prompt change in shell
- add builtin `chmod` and `su` commands
- set default file modes on creation

## Testing
- `make kernel` *(fails: cannot fetch dependencies)*