### PR TITLE
Add ls command and new initramfs directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@ A WIP Operating System
 
 based on: https://github.com/Andrej123456789/limine-loading-template
 
-currently has: 
-- shell
-- elf execution
-- vmm
-- pmm (kinda)
+currently has:
+- shell with basic built-in commands
+- ELF execution
+- VMM
+- PMM (kinda)
 - userspace (not finished)
-- initramfs
+- initramfs with /bin, /home, /etc and /dev directories

--- a/initramfs.txt
+++ b/initramfs.txt
@@ -1,3 +1,11 @@
+bin/
+home/
+etc/
+dev/
+bin/hello
+bin/cat
+bin/echo
+bin/ls
 hello.txt
 world.txt
 ext2.img

--- a/kernel/src/src/shell.c
+++ b/kernel/src/src/shell.c
@@ -190,6 +190,8 @@ static void shell_exec(const char *cmd, char *argv[], int argc) {
         shell_print_colored("║ ", ANSI_CYAN);
         shell_print_colored("  cd     - Change directory         ║\n", ANSI_CYAN);
         shell_print_colored("║ ", ANSI_CYAN);
+        shell_print_colored("  ls     - List files              ║\n", ANSI_CYAN);
+        shell_print_colored("║ ", ANSI_CYAN);
         shell_print_colored("  reboot - Reboot the system        ║\n", ANSI_CYAN);
         shell_print_colored("║ ", ANSI_CYAN);
         shell_print_colored("  gui    - Start GUI demo          ║\n", ANSI_CYAN);
@@ -228,8 +230,18 @@ static void shell_exec(const char *cmd, char *argv[], int argc) {
             }
         }
         // No output on success, following Unix convention
+    } else if (!strcmp(cmd, "ls")) {
+        // List files in the current directory
+        size_t n = 0;
+        const struct fs_file *files = fs_list(&n);
+        for (size_t i = 0; i < n; i++) {
+            shell_print(files[i].name);
+            if (files[i].is_dir) shell_print("/");
+            shell_print("  ");
+        }
+        shell_print("\n");
     }
-    // --- External Commands (ELF Execution) --- 
+    // --- External Commands (ELF Execution) ---
     else {
         if (!try_exec_elf_command(cmd, argv, argc)) {
             // If execution wasn't attempted (file not found)

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -40,13 +40,15 @@ clean:
 
 # Install programs to initramfs
 install: all
-	@echo "Creating program CPIO archive..."
-	# Create the archive in the programs dir first, containing only built executables
-	cd bin && find . -maxdepth 1 -type f -print | cpio -o -H newc > ../initramfs_programs.cpio
-
-	@echo "Moving CPIO archive to root..."
-	# Move the programs-only archive to the root, overwriting any previous one
+	@echo "Creating initramfs with directories..."
+	rm -rf initramfs_root
+	mkdir -p initramfs_root/bin initramfs_root/home initramfs_root/etc initramfs_root/dev
+	for p in $(PROG_NAMES); do \
+	cp bin/$$p initramfs_root/bin/; \
+	done
+	cd initramfs_root && find . | cpio -o -H newc > ../initramfs_programs.cpio
 	mv initramfs_programs.cpio ../initramfs.cpio
+	rm -rf initramfs_root
 
 .PHONY: build install clean
 build: install


### PR DESCRIPTION
## Summary
- support directory creation in the initramfs and add default folders
- expose directories in file listings
- implement built‑in `ls` command for the shell
- package user programs under `/bin` and create standard directories during build
- document the new layout

## Testing
- `make -n programs`