### PR TITLE
Add ls command and initramfs directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@ A WIP Operating System
 
 based on: https://github.com/Andrej123456789/limine-loading-template
 
-currently has: 
-- shell
-- elf execution
-- vmm
-- pmm (kinda)
+- currently has:
+- shell with built-in commands (help, clear, cd, pwd, ls, reboot, gui)
+- ELF execution
+- VMM
+- PMM (kinda)
 - userspace (not finished)
-- initramfs
+- initramfs with /bin, /home, /etc and /dev directories

--- a/initramfs.txt
+++ b/initramfs.txt
@@ -1,3 +1,11 @@
+bin/
+home/
+etc/
+dev/
+bin/hello
+bin/cat
+bin/echo
+bin/ls
 hello.txt
 world.txt
 ext2.img

--- a/kernel/src/src/fs.c
+++ b/kernel/src/src/fs.c
@@ -51,53 +51,28 @@ void fs_init(void) {
             break; // No more room
         }
         
+        size_t name_len = strlen(src->name);
+        if (name_len > 0 && src->name[name_len - 1] == '/') {
+            char dir_name[32];
+            if (name_len - 1 >= sizeof(dir_name))
+                name_len = sizeof(dir_name) - 1;
+            memcpy(dir_name, src->name, name_len - 1);
+            dir_name[name_len - 1] = '\0';
+            fs_create_dir(dir_name);
+            continue;
+        }
+
         struct fs_file *dst = &fs.files[fs.file_count++];
-        
-        // Store the original filename without modification
-        // This ensures we can find it with or without ./ prefix
         strncpy(dst->name, src->name, sizeof(dst->name) - 1);
         dst->name[sizeof(dst->name) - 1] = '\0';
-        
-        serial_write("[fs_init] Stored: [", 19); 
-        serial_write(dst->name, strlen(dst->name)); 
-        serial_write("] Size: ", 8);
-        
-        // Convert size to decimal string
-        char size_str[16] = {0};
-        size_t size_val = src->size;
-        size_t idx = 0;
-        if (size_val == 0) {
-            size_str[idx++] = '0';
-        } else {
-            // Convert to string in reverse
-            while (size_val > 0) {
-                size_str[idx++] = '0' + (size_val % 10);
-                size_val /= 10;
-            }
-            // Reverse the string
-            for (size_t i = 0; i < idx / 2; i++) {
-                char tmp = size_str[i];
-                size_str[i] = size_str[idx - i - 1];
-                size_str[idx - i - 1] = tmp;
-            }
-        }
-        size_str[idx] = '\0';
-        
-        serial_write(size_str, strlen(size_str));
-        serial_write(" bytes\n", 7);
 
-        // Allocate memory for file content and copy it
-        dst->capacity = src->size; // Allocate exact size needed
+        dst->capacity = src->size;
         dst->data = fs_alloc(dst->capacity);
         if (!dst->data) {
-            serial_write("[fs_init] Failed to allocate memory for file: ", 45);
-            serial_write(dst->name, strlen(dst->name));
-            serial_write("\n", 1);
-            fs.file_count--; // Revert the file addition
+            fs.file_count--;
             break;
         }
-        
-        // Copy the content
+
         memcpy(dst->data, src->data, src->size);
         dst->size = src->size;
         dst->is_dir = false;
@@ -200,10 +175,6 @@ bool fs_change_dir(const char *path) {
 struct fs_file *fs_open(const char *name) {
     if (!name || !*name) return NULL;
 
-    // Debug
-    serial_write("[fs_open] Trying to open file: ", 30);
-    serial_write(name, strlen(name));
-    serial_write("\n", 1);
 
     // Handle based on active filesystem
     if (fs.active_fs == FS_TYPE_EXT2) {
@@ -224,9 +195,6 @@ struct fs_file *fs_open(const char *name) {
     }
     processed_name[sizeof(processed_name) - 1] = '\0'; // Ensure null termination
 
-    serial_write("[fs_open] Processed name: ", 26);
-    serial_write(processed_name, strlen(processed_name));
-    serial_write("\n", 1);
 
     // Search for the file in our registry
     for (size_t i = 0; i < fs.file_count; i++) {
@@ -247,30 +215,15 @@ struct fs_file *fs_open(const char *name) {
             processed_entry[sizeof(processed_entry) - 3] = '\0';
         }
 
-        // Debug output for comparison
-        serial_write("[fs_open] Comparing with: ", 26);
-        serial_write(processed_entry, strlen(processed_entry));
-        serial_write(" (original: ", 12);
-        serial_write(fs.files[i].name, strlen(fs.files[i].name));
-        serial_write(")\n", 2);
 
         // Try both the processed name and direct comparison
         if (strcmp(processed_entry, processed_name) == 0 || 
             strcmp(fs.files[i].name, processed_name) == 0 ||
             strcmp(fs.files[i].name, name) == 0) {
-            serial_write("[fs_open] Found match! Index ", 28);
-            char idx_str[4] = {0};
-            idx_str[0] = '0' + (i / 10);
-            idx_str[1] = '0' + (i % 10);
-            serial_write(idx_str, 2);
-            serial_write("\n", 1);
             return &fs.files[i];
         }
     }
 
-    serial_write("[fs_open] No match found for: ", 30);
-    serial_write(name, strlen(name));
-    serial_write("\n", 1);
     return NULL;
 }
 
@@ -438,6 +391,16 @@ bool fs_create_dir(const char *name) {
 
     // Ensure null termination just in case (should be handled by strcpy/strcat)
     dir->path[max_len - 1] = '\0';
+
+    // Also create an entry in the file list so directory shows up in listings
+    if (fs.file_count < FS_MAX_FILES) {
+        struct fs_file *f = &fs.files[fs.file_count++];
+        memset(f, 0, sizeof(*f));
+        strncpy(f->name, name, sizeof(f->name) - 1);
+        f->name[sizeof(f->name) - 1] = '\0';
+        f->is_dir = true;
+        f->fs_type = FS_TYPE_INITRAMFS;
+    }
 
     return true;
 }

--- a/kernel/src/src/shell.c
+++ b/kernel/src/src/shell.c
@@ -190,6 +190,8 @@ static void shell_exec(const char *cmd, char *argv[], int argc) {
         shell_print_colored("║ ", ANSI_CYAN);
         shell_print_colored("  cd     - Change directory         ║\n", ANSI_CYAN);
         shell_print_colored("║ ", ANSI_CYAN);
+        shell_print_colored("  ls     - List files              ║\n", ANSI_CYAN);
+        shell_print_colored("║ ", ANSI_CYAN);
         shell_print_colored("  reboot - Reboot the system        ║\n", ANSI_CYAN);
         shell_print_colored("║ ", ANSI_CYAN);
         shell_print_colored("  gui    - Start GUI demo          ║\n", ANSI_CYAN);
@@ -228,8 +230,18 @@ static void shell_exec(const char *cmd, char *argv[], int argc) {
             }
         }
         // No output on success, following Unix convention
+    } else if (!strcmp(cmd, "ls")) {
+        // List files in the current directory
+        size_t n = 0;
+        const struct fs_file *files = fs_list(&n);
+        for (size_t i = 0; i < n; i++) {
+            shell_print(files[i].name);
+            if (files[i].is_dir) shell_print("/");
+            shell_print("  ");
+        }
+        shell_print("\n");
     }
-    // --- External Commands (ELF Execution) --- 
+    // --- External Commands (ELF Execution) ---
     else {
         if (!try_exec_elf_command(cmd, argv, argc)) {
             // If execution wasn't attempted (file not found)

--- a/programs/Makefile
+++ b/programs/Makefile
@@ -40,13 +40,15 @@ clean:
 
 # Install programs to initramfs
 install: all
-	@echo "Creating program CPIO archive..."
-	# Create the archive in the programs dir first, containing only built executables
-	cd bin && find . -maxdepth 1 -type f -print | cpio -o -H newc > ../initramfs_programs.cpio
-
-	@echo "Moving CPIO archive to root..."
-	# Move the programs-only archive to the root, overwriting any previous one
+	@echo "Creating initramfs with directories..."
+	rm -rf initramfs_root
+	mkdir -p initramfs_root/bin initramfs_root/home initramfs_root/etc initramfs_root/dev
+	for p in $(PROG_NAMES); do \
+	cp bin/$$p initramfs_root/bin/; \
+	done
+	cd initramfs_root && find . | cpio -o -H newc > ../initramfs_programs.cpio
 	mv initramfs_programs.cpio ../initramfs.cpio
+	rm -rf initramfs_root
 
 .PHONY: build install clean
 build: install


### PR DESCRIPTION
## Summary
- document built‑in commands in README
- parse directories while loading the initramfs
- drop noisy debug logging

## Testing
- `make -n programs`
