### PR TITLE
Add double buffering to gui

### DIFF
--- a/kernel/src/src/gui.h
+++ b/kernel/src/src/gui.h
@@ -6,6 +6,7 @@
 
 struct gui_context {
     uint32_t *fb;
+    uint32_t *backbuffer;
     unsigned int width;
     unsigned int height;
     unsigned int pitch;
@@ -37,5 +38,6 @@ void gui_draw_window_ex(struct gui_context *ctx, struct gui_window *win,
 bool gui_window_handle_click(struct gui_window *win, int x, int y);
 void gui_draw_cursor(struct gui_context *ctx, int x, int y, uint32_t color);
 void gui_run_demo(struct gui_context *ctx);
+void gui_flush(struct gui_context *ctx);
 
 #endif // GUI_H


### PR DESCRIPTION
## Summary
- improve `gui_context` with backbuffer
- draw GUI elements to the backbuffer and flush each frame

## Testing
- `make -C kernel` *(fails: Please run the ./get-deps script first)*